### PR TITLE
Uses the correct ob data model repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
 
-        <ob.sdk.version>3.1.2.5</ob.sdk.version>
+        <ob.uk.datamodel.version>3.1.2.9</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.19</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
 
@@ -117,9 +117,9 @@
                 <version>${eidas.psd2.sdk.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.forgerock.openbanking</groupId>
-                <artifactId>openbanking-sdk</artifactId>
-                <version>${ob.sdk.version}</version>
+            	<groupId>com.forgerock.openbanking.uk</groupId>
+            	<artifactId>openbanking-uk-datamodel</artifactId>
+            	<version>${ob.uk.datamodel.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.openbanking4.spring.security</groupId>


### PR DESCRIPTION
The new openbanking toolkit repos are using versions of libraries built by this repo;
https://github.com/ForgeRock/OpenBanking-UK-Datamodel-Java-SDK

And they should be using libraries from the code in this repo;
https://github.com/OpenBankingToolkit/openbanking-uk-datamodel

All the dependencies of libraries in the new repos need to be updated to use binaries from this new repo.