### PR TITLE
Release/1.0.75

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
 
         <ob.uk.datamodel.version>3.1.2.20</ob.uk.datamodel.version>
-        <ob.uk.extensions.version>1.0.11</ob.uk.extensions.version>
         <eidas.psd2.sdk.version>1.19</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
 
@@ -134,12 +133,6 @@
                 <groupId>dev.openbanking4.spring.security</groupId>
                 <artifactId>spring-security-multi-auth-starter</artifactId>
                 <version>${spring-security-multi-auth-starter.version}</version>
-            </dependency>
-            <!-- openbanking extensions -->
-            <dependency>
-                <groupId>com.forgerock.openbanking</groupId>
-                <artifactId>forgerock-openbanking-uk-extensions</artifactId>
-                <version>${ob.uk.extensions.version}</version>
             </dependency>
             <!-- Spring -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.0.75</version>
+    <version>1.0.76-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -440,7 +440,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>1.0.75</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.0.75-SNAPSHOT</version>
+    <version>1.0.75</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -440,7 +440,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>HEAD</tag>
+    <tag>1.0.75</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
**Release 1.0.75**
- Deleted [uk extensions](https://github.com/OpenBankingToolkit/openbanking-uk-extensions) dependency to inject directly on [reference implementation](https://github.com/OpenBankingToolkit/openbanking-reference-implementation)

> Prepare next development iteration.