### PR TITLE
635: use newer version of docker compose and release 1.0.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.0.84-SNAPSHOT</version>
+    <version>1.0.84</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -448,7 +448,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>HEAD</tag>
+    <tag>1.0.84</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <minimal-json.version>0.9.5</minimal-json.version>
         <jmockdata.version>3.1.0</jmockdata.version>
         <docker-compose-rule-junit4.version>0.32.0</docker-compose-rule-junit4.version>
-        <docker-compose-maven-plugin.version>2.2.0</docker-compose-maven-plugin.version>
+        <docker-compose-maven-plugin.version>4.0.0</docker-compose-maven-plugin.version>
         <jackson-datatype-joda.version>2.9.7</jackson-datatype-joda.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <google-cloud-logging-logback-version>0.73.0-alpha</google-cloud-logging-logback-version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.0.84</version>
+    <version>1.0.85-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -448,7 +448,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>1.0.84</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Needed to use newer version of docker-compose-plugin, The old version didn't work with JDK 14.