### PR TITLE
Release/1.0.85

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 | |Current Status|
 |---|---|
 |Build|[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FOpenBankingToolkit%2Fopenbanking-parent%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/OpenBankingToolkit/openbanking-parent/goto?ref=master)|
-|Code coverage|[![codecov](https://codecov.io/gh/OpenBankingToolkit/openbanking-parent/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenBankingToolkit/openbanking-parent)
-|Bintray|[![Bintray](https://img.shields.io/bintray/v/openbanking-toolkit/OpenBankingToolKit/openbanking-parent.svg?maxAge=2592000)](https://bintray.com/openbanking-toolkit/OpenBankingToolKit/openbanking-parent)|
+|Code coverage|[![codecov](https://codecov.io/gh/OpenBankingToolkit/openbanking-parent/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenBankingToolkit/openbanking-parent)|
+|Release|[![GitHub release (latest by date)](https://img.shields.io/github/v/release/OpenBankingToolkit/openbanking-parent.svg)](https://img.shields.io/github/v/release/OpenBankingToolkit/openbanking-parent)|
 |License|![license](https://img.shields.io/github/license/ACRA/acra.svg)|
 
 **_This repository is part of the Open Banking Tool kit. If you just landed to that repository looking for our tool kit,_

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.0.85-SNAPSHOT</version>
+    <version>1.0.85</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -448,7 +448,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>HEAD</tag>
+    <tag>1.0.85</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.0.85</version>
+    <version>1.0.86-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -448,7 +448,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>1.0.85</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
 
-        <ob.uk.datamodel.version>3.1.2.24</ob.uk.datamodel.version>
+        <ob.uk.datamodel.version>3.1.2.26</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.19</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
 


### PR DESCRIPTION
**Release 1.0.85**
- Merge release [v1.0.85](https://github.com/OpenBankingToolkit/openbanking-parent/releases/tag/1.0.85)
- Readme updated to use the github release shield.
- Prepare for the next development iteration.