### PR TITLE
Bumped/upgrade dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
 
-        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+        <spring-cloud.version>Greenwich.SR6</spring-cloud.version>
 
-        <ob.uk.datamodel.version>3.1.2.26</ob.uk.datamodel.version>
-        <eidas.psd2.sdk.version>1.19</eidas.psd2.sdk.version>
+        <ob.uk.datamodel.version>3.1.6.0</ob.uk.datamodel.version>
+        <eidas.psd2.sdk.version>1.27</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
 
         <jodatime.version>2.9.9</jodatime.version>
@@ -59,7 +59,7 @@
         <jersey.version>2.25.1</jersey.version>
         <junit.version>4.12</junit.version>
         <jwt.nimbus.version>9.0.1</jwt.nimbus.version>
-        <bouncycastle.version>1.62</bouncycastle.version>
+        <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.6</slf4j.version>
         <swagger.version>2.9.2</swagger.version>
         <swagger.ui.version>2.9.2</swagger.ui.version>
@@ -584,7 +584,7 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${license-maven-plugin.version}</version>
                     <configuration>
-                        <header>file://${maven.multiModuleProjectDirectory}/legal/LICENSE.txt</header>
+                        <header>legal/LICENSE.txt</header>
                         <includes>
                             <include>**/*.java</include>
                             <include>pom.xml</include>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <jodatime.version>2.9.9</jodatime.version>
         <apache.version>4.5.9</apache.version>
         <jersey.version>2.25.1</jersey.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
         <jwt.nimbus.version>9.0.1</jwt.nimbus.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <slf4j.version>1.7.6</slf4j.version>
@@ -87,7 +87,7 @@
         <catch-exception.version>2.0</catch-exception.version>
         <jsoup.version>1.11.2</jsoup.version>
         <csv.version>2.1.0</csv.version>
-        <jackson-databind.version>2.9.10.1</jackson-databind.version>
+        <jackson-databind.version>2.9.10.7</jackson-databind.version>
 
         <guava.version>28.0-jre</guava.version>
         <javax.version>4.0.1</javax.version>


### PR DESCRIPTION
- Bumped `spring-cloud` version `Greenwitch.SR1` to `Greenwich.SR6`
- Bumped [uk-datamodel](https://github.com/OpenBankingToolkit/openbanking-uk-datamodel) version to latest version [3.1.6.0](https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/releases/tag/3.1.6.0)
- Bumped [eidas-psd2-sdk](https://github.com/OpenBankingToolkit/eidas-psd2-sdk) version to latest version [1.27](https://github.com/OpenBankingToolkit/eidas-psd2-sdk/releases/tag/1.27)
- Bumped `bouncycastle` to align the version `1.68` used in [eidas-psd2-sdk](https://github.com/OpenBankingToolkit/eidas-psd2-sdk)
- Bumped `jackson-databind` to `2.9.10.7` to avoid security vulnerabilities.
- Bumped `junit` to `4.13.1` to avoid security vulnerabilities.

Issue: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/85