### PR TITLE
Release/1.1.88

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.1.88</version>
+    <version>1.1.89-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -454,7 +454,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>1.1.88</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.1.88-SNAPSHOT</version>
+    <version>1.1.88</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -454,7 +454,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-    <tag>HEAD</tag>
+    <tag>1.1.88</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <spring-cloud.version>Greenwich.SR6</spring-cloud.version>
 
-        <ob.uk.datamodel.version>3.1.6.1</ob.uk.datamodel.version>
+        <ob.uk.datamodel.version>3.1.6.2</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.27</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
 


### PR DESCRIPTION
- Bumped [uk-datamodel 3.1.6.2](https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/releases/tag/3.1.6.2)
- [Release 1.1.88](https://github.com/OpenBankingToolkit/openbanking-parent/releases/tag/1.1.88) published.
- Prepare for the next development iteration