### PR TITLE
34: Move to new forgerock spring-security-multi-dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
 
         <ob.uk.datamodel.version>3.1.6.3</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.27</eidas.psd2.sdk.version>
-        <spring-security-multi-auth-starter.version>1.0.0</spring-security-multi-auth-starter.version>
+        <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
+        <fr-spring-security-multi-auth-starter.version>1.0.1</fr-spring-security-multi-auth-starter.version>
 
         <jodatime.version>2.9.9</jodatime.version>
         <apache.version>4.5.9</apache.version>
@@ -133,9 +134,14 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.forgeock.spring.security</groupId>
+                <groupId>dev.openbanking4.spring.security</groupId>
                 <artifactId>spring-security-multi-auth-starter</artifactId>
                 <version>${spring-security-multi-auth-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.forgeock.spring.security</groupId>
+                <artifactId>spring-security-multi-auth-starter</artifactId>
+                <version>${fr-spring-security-multi-auth-starter.version}</version>
             </dependency>
             <!-- Spring -->
             <dependency>


### PR DESCRIPTION
Previous PR failed on two accounts;
- The github action failed to publish v1.0.0 of com.forgerock's
  spring-security-multi-auth library, so any child projects moving to
  use the resulting version of the parent pom failed to build.

- In order not to break all existing children it should be possible to
  support both the dev.openbanking4 and the com.forgerock library so
  that clients can be transitioned to the new library in an organised
  fashion rather than breaking anything that updates.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/34