### PR TITLE
34: Release 1.1.93

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.1.93</version>
+    <version>1.1.94-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -464,7 +464,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-        <tag>1.1.93</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.1.93-SNAPSHOT</version>
+    <version>1.1.93</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -464,7 +464,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-        <tag>HEAD</tag>
+        <tag>1.1.93</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
- POM now supports both the dev.openbanking4 and the com.forgerock library so that clients can be transitioned to the new library in an organised fashion rather than breaking anything that updates.

Issue: OpenBankingToolkit/openbanking-toolkit#34