### PR TITLE
35: Release/1.1.96

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <ob.uk.datamodel.version>3.1.6.4</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.27</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
-        <fr-spring-security-multi-auth-starter.version>1.0.1</fr-spring-security-multi-auth-starter.version>
+        <fr-spring-security-multi-auth-starter.version>1.0.2</fr-spring-security-multi-auth-starter.version>
 
         <jodatime.version>2.9.9</jodatime.version>
         <apache.version>4.5.9</apache.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.1.96-SNAPSHOT</version>
+    <version>1.1.96</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -464,7 +464,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-        <tag>HEAD</tag>
+        <tag>1.1.96</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.1.96</version>
+    <version>1.1.97-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -464,7 +464,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-        <tag>1.1.96</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
### Release 1.1.96

Bumped version of bump version of spring-security-multi-auth-starter to fix bouncycastle transitive dependency error.

