### PR TITLE
45: Use fixed uk-datamodel for 3.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <spring-cloud.version>Greenwich.SR6</spring-cloud.version>
 
-        <ob.uk.datamodel.version>3.1.8.1</ob.uk.datamodel.version>
+        <ob.uk.datamodel.version>3.1.8.2</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.27</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
         <fr-spring-security-multi-auth-starter.version>1.0.3</fr-spring-security-multi-auth-starter.version>


### PR DESCRIPTION
OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45