### PR TITLE
Release 1.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.2.6</version>
+    <version>1.2.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -464,7 +464,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-        <tag>1.2.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - Parent</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-parent</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.6</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -464,7 +464,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-parent.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-parent.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.6</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
45: Use fixed uk-datamodel for 3.1.8

OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45