### PR TITLE
815: Use snapshot version of uk-datamodel while developing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <spring-cloud.version>Greenwich.SR6</spring-cloud.version>
 
-        <ob.uk.datamodel.version>3.1.8.4</ob.uk.datamodel.version>
+        <ob.uk.datamodel.version>3.1.8.5-SNAPSHOT</ob.uk.datamodel.version>
         <eidas.psd2.sdk.version>1.27</eidas.psd2.sdk.version>
         <spring-security-multi-auth-starter.version>2.1.5.0.0.53</spring-security-multi-auth-starter.version>
         <fr-spring-security-multi-auth-starter.version>1.0.3</fr-spring-security-multi-auth-starter.version>


### PR DESCRIPTION
N.B. This will need to be updated to release version when uk-datamodel
is stable and released again.

We can then use snapshot versions of openbanking-parent in dependent
projects to pull this new datastore version into our dev binaries.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/815